### PR TITLE
Add Gauss-Newton projector for angle-between-two-vectors cone constraint

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -5,6 +5,9 @@ on: [push, pull_request, workflow_dispatch]
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+
 jobs:
   build_wheels:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: wheels-binary-${{ matrix.os }}-${{ matrix.target }}
           path: dist
-      - if: github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/main'
         name: update prerelease tag
         uses: EndBug/latest-tag@v1.6.2
         with:
@@ -73,7 +73,7 @@ jobs:
           path: dist
 
   prerelease:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
       group: push-${{ github.ref_name }}-prerelease

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64
             cross: true
-          - os: macos-14
+          - os: macos-latest
             target: universal2
             cross: false
 
@@ -98,19 +98,19 @@ jobs:
           makeLatest: true
           artifacts: "wheels/*"
 
-  publish:
-    name: publish to PyPI
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build_wheels, sdist]
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: wheels-*
-          merge-multiple: true
-      - uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing *
+  # publish:
+  #   name: publish to PyPI
+  #   runs-on: ubuntu-latest
+  #   if: "startsWith(github.ref, 'refs/tags/')"
+  #   needs: [build_wheels, sdist]
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: wheels-*
+  #         merge-multiple: true
+  #     - uses: PyO3/maturin-action@v1
+  #       env:
+  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  #       with:
+  #         command: upload
+  #         args: --non-interactive --skip-existing *

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "optik"
-version = "0.5.0-beta.4"
+version = "0.5.0-beta.5+medra"
 dependencies = [
  "approx",
  "criterion",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "optik-cpp"
-version = "0.5.0-beta.4"
+version = "0.5.0-beta.5+medra"
 dependencies = [
  "nalgebra",
  "optik",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "optik-py"
-version = "0.5.0-beta.4"
+version = "0.5.0-beta.5+medra"
 dependencies = [
  "nalgebra",
  "optik",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "nlopt"
 version = "0.7.0"
-source = "git+https://github.com/kylc/rust-nlopt.git?branch=optik-patches#050c9dc0000d5f896297de330cd7511af532cbe4"
+source = "git+https://github.com/hashb/rust-nlopt.git?branch=optik-patches-cmake-version-bump#15e3ff9dc494cf17dcb42075c7b24ab16cf70f9a"
 dependencies = [
  "cmake",
 ]
@@ -464,7 +464,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "optik"
-version = "0.5.0-beta.5+medra"
+version = "0.5.1+medra"
 dependencies = [
  "approx",
  "criterion",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "optik-cpp"
-version = "0.5.0-beta.5+medra"
+version = "0.5.1+medra"
 dependencies = [
  "nalgebra",
  "optik",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "optik-py"
-version = "0.5.0-beta.5+medra"
+version = "0.5.1+medra"
 dependencies = [
  "nalgebra",
  "optik",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 authors = ["Kyle Cesare <kcesare@gmail.com>"]
-version = "0.5.0-beta.4"
+version = "0.5.0-beta.5+medra"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 authors = ["Kyle Cesare <kcesare@gmail.com>"]
-version = "0.5.0-beta.5+medra"
+version = "0.5.1+medra"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.80"

--- a/crates/optik/Cargo.toml
+++ b/crates/optik/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 nalgebra = "0.33"
-nlopt = { git = "https://github.com/kylc/rust-nlopt.git", branch = "optik-patches" }
+nlopt = { git = "https://github.com/hashb/rust-nlopt.git", branch = "optik-patches-cmake-version-bump" }
 ordered-float = "4.2"
 petgraph = "0.6"
 rand = "0.8"

--- a/optik.pyi
+++ b/optik.pyi
@@ -33,10 +33,20 @@ class Robot:
     def fk(
         self, x: VectorXd, ee_offset: MatrixXd | None = ...
     ) -> list[list[float]]: ...
+    def fk_medra(
+        self, x: VectorXd, ee_offset: VectorXd | None = ...
+    ) -> list[float]: ...
     def ik(
         self,
         config: SolverConfig,
         target: MatrixXd,
         x0: VectorXd,
         ee_offset: MatrixXd | None = ...,
+    ) -> tuple[list[float], float] | None: ...
+    def ik_medra(
+        self,
+        config: SolverConfig,
+        target_pose: VectorXd,
+        x0: VectorXd,
+        ee_offset_pose: VectorXd | None = ...,
     ) -> tuple[list[float], float] | None: ...

--- a/optik.pyi
+++ b/optik.pyi
@@ -50,3 +50,13 @@ class Robot:
         x0: VectorXd,
         ee_offset_pose: VectorXd | None = ...,
     ) -> tuple[list[float], float] | None: ...
+
+    def apply_angle_between_two_vectors_constraint(
+        self,
+        source_vec_in_tip_frame: VectorXd,
+        target_vec: VectorXd,
+        max_angle: float,
+        ee_offset_pose: VectorXd,
+        seed_joint_angles: VectorXd,
+        config: SolverConfig,
+    ) -> list[float] | None: ...


### PR DESCRIPTION
## Summary

Adds ``Robot::apply_angle_between_two_vectors_constraint_newton`` — a Gauss-Newton projector for the angle-between-two-vectors cone constraint. Continuous in the seed state, designed to be the projector OMPL's ``ProjectedStateSpace::discreteGeodesic`` calls during edge-checking.

The existing ``apply_angle_between_two_vectors_constraint`` (sampling-based — picks a random angle inside the valid cone, builds a target pose, runs full IK) is correct for finding *some* configuration that satisfies the inequality, but is not continuous in the seed: tiny seed perturbations can hop IK branches, producing large jumps in the projected joint state. OMPL then rejects the resulting edges as discontinuous.

## What's new

### ``apply_angle_between_two_vectors_constraint_newton``

- Operates on the scalar residual ``f(q) = angle(q) - max_angle`` (positive outside the cone, treated as zero inside — encodes the one-sided inequality as an equality).
- If the seed already satisfies the constraint (``f <= tol``), returns it unchanged. No IK call.
- Otherwise takes Newton steps along the analytical gradient
  ``d(angle)/dq = -(1/sin(angle)) · J_w^T · (a × b)``
  where ``a`` is the world-frame tip axis, ``b`` is the world-frame target, and ``J_w`` is the world-frame angular Jacobian. Cross product is computed in world frame and rotated into the EE frame to dot against ``joint_jacobian()``'s local-frame angular rows.
- Joint limits clamped at every step.
- Falls back to one-sided finite differences when ``sin(angle) < 1e-6`` (tip parallel/antiparallel with target — analytical gradient is singular there).
- Bails with ``None`` if the gradient becomes singular (``|grad|² < 1e-12``) or the iteration doesn't converge in ``max_iters`` (default 50).

Because each Newton step depends only on the current ``q`` (no random sampling, no IK branch flip), the resulting projection is Lipschitz-continuous in the seed.

### Python binding

``PyRobot::apply_angle_between_two_vectors_constraint_newton`` (kwargs: ``source_vec_in_tip_frame``, ``target_vec``, ``max_angle``, ``ee_offset_pose``, ``seed_joint_angles``, ``max_iters=50``, ``tol=1e-3``). Stub added to ``optik.pyi``.

### Other (bundled medra-fork housekeeping)

- Workspace version bumped to ``0.5.1+medra`` to distinguish from upstream ``0.5.0-beta.4``.
- Python wheel CI: ``macos-14`` → ``macos-latest``, ``master`` → ``main`` branch refs, PyPI publish job commented out (this fork doesn't publish to PyPI; downstream consumes prerelease tag wheels).
- ``nlopt`` source switched from ``kylc/rust-nlopt:optik-patches`` to ``hashb/rust-nlopt:optik-patches-cmake-version-bump`` for compatibility with newer CMake.
- ``parse_pose`` renormalizes the rotation when the input matrix isn't strictly orthogonal (avoids ``try_convert`` failing on round-tripped float poses).
- ``fk_medra`` / ``ik_medra`` / ``apply_angle_between_two_vectors_constraint``: pose+quaternion (``[px, py, pz, qw, qx, qy, qz]``) variants of the existing matrix-based APIs, matching how Medra represents poses internally.

## Why this exists

Medra's motion planner had been using the sampling-based projector with OMPL's ``ProjectedStateSpace``. On levelness-constrained motions (e.g. P300_8CH dispense at a 30° cone), ``discreteGeodesic`` rejected ~all edges because consecutive projected samples landed in different IK branches. Switching to this Gauss-Newton projector unblocks those motions; full breakdown in [medra-ai/medra_robotics#8353](https://github.com/medra-ai/medra_robotics/pull/8353).